### PR TITLE
[Feat] TODO list 페이지 스타일링 / 수정기능 완성

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@tanstack/react-query": "^5.39.0",
         "@tanstack/react-query-devtools": "^5.40.0",
         "axios": "^1.7.2",
-        "jotai": "^2.8.2",
+        "jotai": "^2.8.3",
         "next": "14.2.3",
         "react": "^18",
         "react-dom": "^18",
@@ -12177,9 +12177,9 @@
       }
     },
     "node_modules/jotai": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.8.2.tgz",
-      "integrity": "sha512-AU+EU82YqP94izfbGYQQL3oa/06gmn+Ijf/CKx0QybAURtbqh2e4N6zA2fxeIh0JEUgASF6z5IhagJ8NicR95A==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.8.3.tgz",
+      "integrity": "sha512-pR4plVvdbzB6zyt7VLLHPMAkcRSKhRIvZKd+qkifQLa3CEziEo1uwZjePj4acTmQrboiISBlYSdCz3gWcr1Nkg==",
       "engines": {
         "node": ">=12.20.0"
       },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@tanstack/react-query": "^5.39.0",
     "@tanstack/react-query-devtools": "^5.40.0",
     "axios": "^1.7.2",
-    "jotai": "^2.8.2",
+    "jotai": "^2.8.3",
     "next": "14.2.3",
     "react": "^18",
     "react-dom": "^18",

--- a/src/app/todolist/page.tsx
+++ b/src/app/todolist/page.tsx
@@ -1,23 +1,25 @@
 'use client';
+import NavBottom from '@/components/NavBottom';
 import Modal from '@/components/todo/Modal';
+import Mood from '@/components/todo/Mood';
 import Timer from '@/components/todo/Timer';
 import ToDoInsert from '@/components/todo/ToDoInsert';
-import ToDoListItem from '@/components/todo/todolistitem';
+import ToDoListItem from '@/components/todo/ToDoListItem';
 import React, { useCallback, useRef, useState } from 'react';
 import { IoMusicalNotesOutline } from 'react-icons/io5';
-import { TbMoodEmpty, TbMoodSad, TbMoodSmile } from 'react-icons/tb';
 
-export type TodoType = {
+export interface TodoType {
   id: number;
   text: string;
   checked: boolean;
-};
+}
 
 function Page() {
   const [value, setValue] = useState<string>('');
   const [todos, setTodos] = useState<TodoType[]>([]);
   const [isModalOpen, setIsModalOpen] = useState<boolean>();
   const [modalIndex, setModalIndex] = useState<number>();
+  const [todoIndex, setTodoIndex] = useState<number>();
 
   const nextId = useRef(0);
   const onInsert = useCallback(
@@ -30,13 +32,13 @@ function Page() {
       if (!text) return alert('TODO를 적어주세요!');
       setTodos(todos.concat(todo));
       nextId.current++;
-      console.log(todo.id);
+      console.log(todos);
     },
     [todos],
   );
 
   const openModal = useCallback((index: number) => {
-    setIsModalOpen(true);
+    setIsModalOpen(isModalOpen => !isModalOpen);
     console.log(index);
     if (modalIndex != undefined) {
       setModalIndex(undefined);
@@ -55,61 +57,66 @@ function Page() {
     [todos],
   );
 
+  const checkIndex = useCallback((id: number) => {
+    setTodoIndex(id);
+  }, []);
+
   return (
-    <div className="flex justify-center bg-black">
-      <div className="w-[23.4375rem] h-[50.75rem] bg-white">
-        <main className="w-full h-auto top-[3.4375rem] relative ">
-          <header className="flex flex-col items-center">
-            <div className="flex w-full h-[3.1875rem] px-5 justify-between items-center border-b-[0.0313rem] border-borderGray">
-              <p className="font-bold text-textGray text-[1.125rem]">이번 달 프로젝트 잘 끝내기</p>
-              <div className="w-[3.75rem] h-[2.375rem] text-veryPurple font-extrabold text-[1.625rem] text-center flex justify-center items-center">
-                D-32
-              </div>
+    <div className="flex container justify-center w-full h-[50.75rem] bg-white">
+      <main className="w-full h-auto top-[3.4375rem] relative ">
+        <header className="flex flex-col items-center">
+          <div className="flex w-full h-[3.1875rem] px-5 justify-between items-center border-b-[0.0313rem] border-borderGray">
+            <p className="font-bold text-black-900 text-[1.125rem]">이번 달 프로젝트 잘 끝내기</p>
+            <div className="w-[3.75rem] h-[2.375rem] text-primary-600 font-extrabold text-[1.625rem] text-center flex justify-center items-center">
+              D-32
             </div>
-            <section className="w-full h-[2.5625rem] flex border-b-[0.0313rem] border-borderGray items-center">
-              <div className="flex w-[8.8125rem] h-[2.5625rem] border-r-[0.0313rem] border-borderGray relative items-center justify-center text-[0.8125rem] font-medium text-textGray">
-                2024. 05. 28
-              </div>
-              <div className="w-[15.5rem] h-[2.5625rem] px-[0.625rem] flex justify-between items-center">
-                <div className="flex w-[4.25rem] h-[1.5625rem] gap-[0.1875rem] items-center">
-                  <TbMoodSmile className="w-[1.5625rem] h-[1.5625rem] text-veryPurple" />
-                  <p className="text-[0.75rem] font-medium text-veryPurple">HAPPY</p>
-                </div>
-                <div className="flex w-[4.25rem] h-[1.5625rem] gap-[0.1875rem] items-center">
-                  <TbMoodEmpty className="w-[1.5625rem] h-[1.5625rem] text-borderGray" />
-                  <p className="text-[0.75rem] font-medium text-borderGray">SOSO</p>
-                </div>
-                <div className="flex w-[4.25rem] h-[1.5625rem] gap-[0.1875rem] items-center">
-                  <TbMoodSad className="w-[1.5625rem] h-[1.5625rem] text-borderGray" />
-                  <p className="text-[0.75rem] font-medium text-borderGray">SAD</p>
-                </div>
-              </div>
-            </section>
-            <section>
-              <div className="flex items-center justify-around w-[23.4375rem] h-[2.5625rem] border-b-[0.0313rem] border-borderGray px-[0.625rem] gap-[0.3125rem]">
-                <Timer />
-              </div>
-            </section>
-            <section className="flex w-full h-[2.5625rem] items-center px-[0.625rem] gap-[0.625rem] border-b-[0.0313rem] border-borderGray">
-              <div>
-                <IoMusicalNotesOutline className="w-[1.25rem] h-[1.25rem]" />
-              </div>
-              <div className="text-[0.75rem] font-medium text-textGray">심규선 - care</div>
-            </section>
-          </header>
-          <section className="flex flex-col w-full h-[20rem] overflow-auto">
-            <div className="border-r-[0.0313rem] border-borderGray w-[2.75rem] h-[20rem] absolute" />
-            <ToDoListItem todos={todos} openModal={openModal} />
+          </div>
+          <section className="w-full h-[2.5625rem] flex border-b-[0.0313rem] border-borderGray items-center">
+            <div className="flex w-[8.8125rem] h-[2rem] border-r-[0.0313rem] border-borderGray relative items-center justify-center text-[0.8125rem] font-medium text-black-900">
+              2024. 05. 28
+            </div>
+            <div className="w-[15.5rem] h-[2rem] px-[0.625rem] flex justify-between items-center">
+              <Mood />
+            </div>
           </section>
-          <ToDoInsert onInsert={onInsert} value={value} setValue={setValue} />
-          {isModalOpen ? <Modal onRemove={onRemove} id={modalIndex as number} /> : <></>}
           <section>
-            <p className="m-2 pb-1 border-b-borderGray border-b w-[3.0625rem] text-center">Memo</p>
-            <textarea name="memo" id="memo" className="w-full h-[5rem] text-[0.875rem] px-2 resize-none"></textarea>
+            <div className="flex items-center justify-around w-[23.4375rem] h-[2.5625rem] border-b-[0.0313rem] border-borderGray px-[0.625rem] gap-[0.3125rem]">
+              <Timer />
+            </div>
           </section>
-          <footer className="w-full h-[5.25rem]">하단 글로벌 네비게이터 들어갈 자리 입니다</footer>
-        </main>
-      </div>
+          <section className="flex w-full h-[2.5625rem] items-center px-[0.625rem] gap-[0.625rem] border-b-[0.0313rem] border-borderGray">
+            <div>
+              <IoMusicalNotesOutline className="w-[1.25rem] h-[1.25rem]" />
+            </div>
+            <div className="text-[0.75rem] font-medium text-black-900">심규선 - care</div>
+          </section>
+        </header>
+        <section className="flex flex-col w-full h-[22rem] overflow-auto">
+          <div className="border-r-[0.0313rem] border-borderGray w-[2.75rem] h-[22rem] absolute" />
+          {todos.map(todo => (
+            <ToDoListItem
+              todo={todo}
+              openModal={openModal}
+              isModalOpen={isModalOpen as boolean}
+              todoIndex={todoIndex as number}
+              checkIndex={checkIndex}
+              modalIndex={modalIndex as number}
+            />
+          ))}
+        </section>
+        <ToDoInsert onInsert={onInsert} value={value} setValue={setValue} />
+        {isModalOpen ? <Modal onRemove={onRemove} id={modalIndex as number} /> : <></>}
+        <section>
+          <p className="m-2 pb-1 border-b-borderGray border-b w-[3.0625rem] text-center">Memo</p>
+          <textarea
+            name="memo"
+            id="memo"
+            className="w-full h-[6rem] text-[0.875rem] px-2 resize-none focus:outline-none"></textarea>
+        </section>
+        <footer className="w-full h-[5.25rem]">
+          <NavBottom />
+        </footer>
+      </main>
     </div>
   );
 }

--- a/src/components/todo/Modal.tsx
+++ b/src/components/todo/Modal.tsx
@@ -4,13 +4,11 @@ interface Props {
 }
 function Modal({ onRemove, id }: Props) {
   return (
-    <div className="w-full flex items-center h-[8.5rem] bg-borderGray absolute bottom-[5.5rem] rounded-t-[0.625rem]">
-      <div className="w-full flex flex-col items-start gap-7 pl-3">
-        {/* <button className="flex font-semibold text-[1.125rem] w-full">수정</button> */}
-        <button className="flex font-semibold text-[1.125rem] w-full text-red-400" onClick={() => onRemove(id)}>
-          삭제
-        </button>
-      </div>
+    <div className="w-full flex flex-col justify-center h-[8.5rem] pl-3 gap-7 bg-[#F2F2F2] absolute bottom-[4rem] rounded-t-[0.625rem]">
+      {/* <button className="flex font-semibold text-[1.125rem] w-full">수정</button> */}
+      <button className="flex font-semibold text-[1.125rem] w-full text-errorRed" onClick={() => onRemove(id)}>
+        삭제
+      </button>
     </div>
   );
 }

--- a/src/components/todo/Modal.tsx
+++ b/src/components/todo/Modal.tsx
@@ -1,11 +1,12 @@
 interface Props {
-  onRemove(id: number): void;
-  id: number;
+  onRemove(id?: number): void;
+  onEdit(id?: number): void;
+  id?: number;
 }
-function Modal({ onRemove, id }: Props) {
+function Modal({ onRemove, onEdit, id }: Props) {
   return (
     <div className="w-full flex flex-col justify-center h-[8.5rem] pl-3 gap-7 bg-[#F2F2F2] absolute bottom-[4rem] rounded-t-[0.625rem]">
-      {/* <button className="flex font-semibold text-[1.125rem] w-full">수정</button> */}
+      <button className="flex font-semibold text-[1.125rem] w-full" onClick={() => onEdit(id)}>수정</button>
       <button className="flex font-semibold text-[1.125rem] w-full text-errorRed" onClick={() => onRemove(id)}>
         삭제
       </button>

--- a/src/components/todo/Mood.tsx
+++ b/src/components/todo/Mood.tsx
@@ -1,0 +1,46 @@
+import React, { useState } from 'react';
+import { TbMoodEmpty, TbMoodSad, TbMoodSmile } from 'react-icons/tb';
+
+function Mood() {
+  const [selectMood, setSelectMood] = useState<string>('');
+
+  const handleSelect = (selectMood: string) => {
+    setSelectMood(selectMood);
+  };
+
+  return (
+    <>
+      <div className="flex w-[4.25rem] h-[1.5625rem] gap-[0.1875rem] items-center">
+        <label className="flex items-center gap-[0.1875rem]">
+          <input type="radio" name="mood" value="happy" className="hidden" onClick={() => handleSelect('happy')} />
+          <TbMoodSmile
+            className={`w-[1.5625rem] h-[1.5625rem] ${selectMood === 'happy' ? 'text-primary-600' : 'text-black-200'}`}
+          />
+          <p className={`text-[0.75rem] font-medium ${selectMood === 'happy' ? 'text-primary-600' : 'text-black-200'}`}>
+            HAPPY
+          </p>
+        </label>
+      </div>
+      <label className="flex items-center gap-[0.1875rem]">
+        <input type="radio" name="mood" value="soso" className="hidden" onClick={() => handleSelect('soso')} />
+        <TbMoodEmpty
+          className={`w-[1.5625rem] h-[1.5625rem] ${selectMood === 'soso' ? 'text-primary-600' : 'text-black-200'}`}
+        />
+        <p className={`text-[0.75rem] font-medium ${selectMood === 'soso' ? 'text-primary-600' : 'text-black-200'}`}>
+          SO SO
+        </p>
+      </label>
+      <label className="flex items-center gap-[0.1875rem]">
+        <input type="radio" name="mood" value="sad" className="hidden" onClick={() => handleSelect('sad')} />
+        <TbMoodSad
+          className={`w-[1.5625rem] h-[1.5625rem] ${selectMood === 'sad' ? 'text-primary-600' : 'text-black-200'}`}
+        />
+        <p className={`text-[0.75rem] font-medium ${selectMood === 'sad' ? 'text-primary-600' : 'text-black-200'}`}>
+          SAD
+        </p>
+      </label>
+    </>
+  );
+}
+
+export default Mood;

--- a/src/components/todo/Timer.tsx
+++ b/src/components/todo/Timer.tsx
@@ -14,9 +14,9 @@ function Timer() {
         setSeconds(seconds => seconds + 1);
       }, 1000);
     } else if (!isActive && seconds !== 0) {
-      clearInterval(interval!);
+      clearInterval(interval! as NodeJS.Timeout);
     }
-    return () => clearInterval(interval);
+    return () => clearInterval(interval as NodeJS.Timeout);
   }, [isActive, seconds]);
 
   const handleStartStop = (): void => {
@@ -48,19 +48,19 @@ function Timer() {
   return (
     <>
       <div>
-        <LuTimer className="w-[1.3125rem] h-[1.3125rem]" />
+        <LuTimer className="w-[1.3125rem] h-[1.3125rem] text-black-900" />
       </div>
-      <div className="flex items-center w-[19rem] h-[2.5625rem] font-medium text-[0.875rem] text-textGray">
+      <div className="flex items-center w-[19rem] h-[2rem] font-medium text-[0.875rem] text-textGray">
         {formatTime(seconds)}
       </div>
       {isActive ? (
         <button type="button" onClick={handleStartStop}>
-          <BsStopCircle className="w-[1.625rem] h-[1.625rem] text-purple-400" />
+          <BsStopCircle className="w-[1.625rem] h-[1.625rem] text-primary-400" />
         </button>
       ) : (
         <>
           <button type="button" onClick={() => setIsActive(true)}>
-            <BsSkipStartCircle className="w-[1.625rem] h-[1.625rem] text-borderGray" />
+            <BsSkipStartCircle className="w-[1.625rem] h-[1.625rem] text-black-200" />
           </button>
           {/* <button type="button" onClick={handleReset}>
             <BiReset className="w-[1.625rem] h-[1.625rem] text-red-400" />

--- a/src/components/todo/ToDoInsert.tsx
+++ b/src/components/todo/ToDoInsert.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 import { AiOutlinePlus } from 'react-icons/ai';
 
 interface Props {
@@ -8,12 +8,12 @@ interface Props {
 }
 
 function ToDoInsert({ onInsert, value, setValue }: Props) {
-  const onChange = e => {
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setValue(e.target.value);
     console.log(value);
   };
   const onSubmit = useCallback(
-    e => {
+    (e: React.FormEvent) => {
       onInsert(value);
       setValue('');
       e.preventDefault();
@@ -26,13 +26,13 @@ function ToDoInsert({ onInsert, value, setValue }: Props) {
     <form className="w-full h-[2.625rem] flex" onSubmit={onSubmit}>
       <input
         type="text"
-        className="border-borderGray border w-[20.8125rem] h-[2.625rem] pl-2 focus:outline-none"
+        className="border-black-200 border w-full h-[2.625rem] pl-2 focus:outline-none"
         placeholder="TODO는 이곳에 적어주세요!"
         onChange={onChange}
         value={value}
       />
       <button
-        className={`flex items-center justify-center w-[2.625rem] h-[2.625rem] ${value ? 'bg-veryPurple' : 'bg-borderGray'} active:bg-lightPurple`}>
+        className={`flex items-center justify-center w-[2.625rem] h-[2.625rem] ${value ? 'bg-primary-400' : 'bg-black-200'} active:bg-primary-200`}>
         <AiOutlinePlus className="text-[2rem] text-white" />
       </button>
     </form>

--- a/src/components/todo/ToDoInsert.tsx
+++ b/src/components/todo/ToDoInsert.tsx
@@ -1,26 +1,30 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { AiOutlinePlus } from 'react-icons/ai';
 
 interface Props {
-  onInsert: (value: string) => void;
-  value: string;
-  setValue: (text: string) => void;
+  init?: string;
+  onInsert(value?: string): void;
 }
 
-function ToDoInsert({ onInsert, value, setValue }: Props) {
+function ToDoInsert({init, onInsert}: Props) {
+  const [value, setValue] = useState<string>(init ?? "");
+
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setValue(e.target.value);
-    console.log(value);
   };
+
   const onSubmit = useCallback(
     (e: React.FormEvent) => {
-      onInsert(value);
       setValue('');
       e.preventDefault();
-      console.log(value);
+      onInsert(value);
     },
-    [onInsert, value],
+    [value, onInsert],
   );
+
+  useEffect(() => {
+    setValue(init ?? "");
+  }, [init]);
 
   return (
     <form className="w-full h-[2.625rem] flex" onSubmit={onSubmit}>

--- a/src/components/todo/ToDoListItem.tsx
+++ b/src/components/todo/ToDoListItem.tsx
@@ -1,28 +1,49 @@
 import { TodoType } from '@/app/todolist/page';
+import { useState } from 'react';
 import { BsThreeDots } from 'react-icons/bs';
+import { IoMdCheckbox } from 'react-icons/io';
+import { MdCheckBoxOutlineBlank } from 'react-icons/md';
 
 interface Props {
-  todos: TodoType[];
+  todo: TodoType;
   openModal(index: number): void;
+  isModalOpen: boolean;
+  todoIndex: number;
+  checkIndex(id: number): void;
+  modalIndex: number;
 }
 
-function ToDoListItem({ todos, openModal }: Props) {
+function ToDoListItem({ todo, openModal, isModalOpen, todoIndex, checkIndex, modalIndex }: Props) {
+  const [isCompleted, setIsCompleted] = useState<boolean>(false);
+
+  const handleComplete = (id: number) => {
+    if (id === todoIndex) {
+      setIsCompleted(isCompleted => !isCompleted);
+      console.log(id);
+      console.log(todoIndex);
+    }
+  };
+
   return (
     <>
-      {todos.map(todo => (
-        <div className="flex items-center" key={todo.id}>
-          <label className="flex w-full h-[2.625rem] items-center py-[0.765rem] pl-[0.765rem]">
-            <input type="checkbox" name="잠자기" value={1} className="w-[1.25rem] h-[1.25rem] z-10" />
-            <span className="flex w-full h-auto pl-[1.5rem] items-center justify-between">
-              <p className="text-Gray  font-medium">{todo.text}</p>
-            </span>
-          </label>
-          <BsThreeDots
-            className="w-[50px] text-borderGray text-[1.25rem] px-[0.625rem] cursor-pointer"
-            onClick={() => openModal(todo.id)}
-          />
-        </div>
-      ))}
+      <div className="flex items-center" key={todo.id} onClick={() => checkIndex(todo.id)}>
+        <label
+          className="flex w-full h-[2.625rem] items-center py-[0.765rem] pl-[0.765rem]"
+          onClick={() => handleComplete(todo.id)}>
+          {isCompleted ? (
+            <IoMdCheckbox className="text-primary-400 w-[1.25rem] h-[1.25rem] z-[1]" />
+          ) : (
+            <MdCheckBoxOutlineBlank className="w-[1.25rem] h-[1.25rem] z-[1]" />
+          )}
+          <span className="flex w-full h-auto pl-[1.5rem] items-center justify-between">
+            <p className={`${isCompleted ? 'text-black-200' : 'text-black-900'} font-medium`}>{todo.text}</p>
+          </span>
+        </label>
+        <BsThreeDots
+          className={`w-[50px] text-primary- ${modalIndex === todo.id && isModalOpen ? 'text-primary-400' : 'text-black-200'} text-[1.25rem] px-[0.625rem] cursor-pointer`}
+          onClick={() => openModal(todo.id)}
+        />
+      </div>
     </>
   );
 }

--- a/src/components/todo/ToDoListItem.tsx
+++ b/src/components/todo/ToDoListItem.tsx
@@ -7,36 +7,25 @@ import { MdCheckBoxOutlineBlank } from 'react-icons/md';
 interface Props {
   todo: TodoType;
   openModal(index: number): void;
-  isModalOpen: boolean;
-  todoIndex: number;
-  checkIndex(id: number): void;
-  modalIndex: number;
+  handleComplete(index: number): void;
+  isModalOpen?: boolean;
+  modalIndex?: number;
 }
 
-function ToDoListItem({ todo, openModal, isModalOpen, todoIndex, checkIndex, modalIndex }: Props) {
-  const [isCompleted, setIsCompleted] = useState<boolean>(false);
-
-  const handleComplete = (id: number) => {
-    if (id === todoIndex) {
-      setIsCompleted(isCompleted => !isCompleted);
-      console.log(id);
-      console.log(todoIndex);
-    }
-  };
-
+function ToDoListItem({ todo, openModal, handleComplete, isModalOpen, modalIndex }: Props) {
   return (
     <>
-      <div className="flex items-center" key={todo.id} onClick={() => checkIndex(todo.id)}>
+      <div className="flex items-center" >
         <label
           className="flex w-full h-[2.625rem] items-center py-[0.765rem] pl-[0.765rem]"
           onClick={() => handleComplete(todo.id)}>
-          {isCompleted ? (
+          {todo.checked ? (
             <IoMdCheckbox className="text-primary-400 w-[1.25rem] h-[1.25rem] z-[1]" />
           ) : (
             <MdCheckBoxOutlineBlank className="w-[1.25rem] h-[1.25rem] z-[1]" />
           )}
           <span className="flex w-full h-auto pl-[1.5rem] items-center justify-between">
-            <p className={`${isCompleted ? 'text-black-200' : 'text-black-900'} font-medium`}>{todo.text}</p>
+            <p className={`${todo.checked ? 'text-black-200' : 'text-black-900'} font-medium`}>{todo.text}</p>
           </span>
         </label>
         <BsThreeDots

--- a/src/stories/TodoInput.tsx
+++ b/src/stories/TodoInput.tsx
@@ -1,0 +1,28 @@
+import React, { useState } from 'react';
+import { AiOutlinePlus } from 'react-icons/ai';
+
+const TodoInput = () => {
+  const [value, setValue] = useState<string>();
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setValue(e.target.value);
+    console.log(value);
+  };
+
+  return (
+    <form className="w-full h-[2.625rem] flex">
+      <input
+        type="text"
+        className="border-black-200 border w-full h-[2.625rem] pl-2 focus:outline-none"
+        placeholder="TODO는 이곳에 적어주세요!"
+        onChange={onChange}
+        value={value}
+      />
+      <button
+        className={`flex items-center justify-center w-[2.625rem] h-[2.625rem] ${value ? 'bg-primary-400' : 'bg-black-200'} active:bg-primary-200`}>
+        <AiOutlinePlus className="text-[2rem] text-white" />
+      </button>
+    </form>
+  );
+};
+export default TodoInput;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #30 

## 📝작업 내용

> 오늘의 기분 선택시 보라색으로 변경되게 했습니다. (1개만 선택 가능)
> TODO 체크 완료시 TODO text가 회색 처리가 되도록 했습니다.
> 더보기 (삭제/수정) 버튼 클릭시 해당하는 TODO의 버튼만 보라색으로 변경되게 했습니다.
> 갖가지의 스타일을 공통 스타일 컴포넌트로 수정했습니다.
> 하단 글로벌 네비게이션을 추가했으며 맞지 않던 크기들을 조절했습니다.

> 공통 Input 컴포넌트를 생성했습니다. 이름은.. 어떻게 지어야할지 몰라서 막 지었습니다😭
(사용법을 봐도 어떻게 사용하는지 잘 감이 안와서.. 만들긴했는데.. 역시 잘 모르겠습니다😭)

-6월 7일 추가-

> TODO list 수정 기능을 완성하였습니다. (개발자 친구가 도와줬습니다🥸)
> 타입 정의에 관해서 수정이 이루어졌습니다.


## 🛠️추후 수정

> 멘토링 시간에 봤던 모달창 애니메이션, 바깥 div 클릭시 사라지는 기능을 구현 할 예정입니다.
(당장은 안하고 음악 플레이어 기능까지 마저 넣고 진행할 것 같습니다🥲)

### 스크린샷 (선택)

![무제1](https://github.com/OZ-Coding-School/oz_02_main-004-FE/assets/154216904/cb1810b9-2fff-4900-b136-414da579c042)


-6월 7일 추가-

![무제 2](https://github.com/OZ-Coding-School/oz_02_main-004-FE/assets/154216904/e85105a0-f5e7-45bb-a6f7-141d639a7cd4)



## 💬리뷰 요구사항(선택)

> 리뷰는 언제나 환영입니다!

> 휴일 잘 보내세요🥳

## 특이사항

> beingapple은 친구 계정입니다 ㅠㅠ... 친구 맥으로 작업하고 PR수정해서 올렸더니.. 친구 깃으로 올려졌네요.. 참고 부탁드립니다!!
