### PR TITLE
Modal 간단한 추상화 예시 코드

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -22,6 +22,7 @@ export default function RootLayout({
         <link rel="icon" href="/PTDLogo.png" sizes="any" />
         <body className={notoSansKR.className}>
           <div className="w-mobile h-mobile">{children}</div>
+          <div id="modal-root" />
         </body>
       </html>
     </ReactQueryClientProvider>

--- a/src/components/modal/ModalWrapper.tsx
+++ b/src/components/modal/ModalWrapper.tsx
@@ -1,0 +1,23 @@
+import React, { ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+
+interface ModalWrapperProps {
+  children: ReactNode;
+  onClose: () => void;
+}
+
+/**
+ * 모달을 띄웠을 때 background로 깔리는 component
+ * 색상 커스텀이 필요하면 props로 추가하기
+ */
+const ModalWrapper = ({ children, onClose }: ModalWrapperProps) => {
+  return createPortal(
+    <div className="w-mobile h-mobile absolute top-0 z-30 left-[197px] bg-black-600/30" onClick={onClose}>
+      {children}
+    </div>,
+    // 모달이 켜질 때는 이미 layout 컴포넌트가 실행된 이후 이기 때문에 "!"로 타입 강제
+    document.querySelector('#modal-root')!,
+  );
+};
+
+export default ModalWrapper;

--- a/src/components/todo/Modal.tsx
+++ b/src/components/todo/Modal.tsx
@@ -1,17 +1,24 @@
+import ModalWrapper from '../modal/ModalWrapper';
+
 interface Props {
   onRemove(id: number): void;
+  onClose: () => void;
   id: number;
 }
-function Modal({ onRemove, id }: Props) {
+function Modal({ onRemove, id, onClose }: Props) {
   return (
-    <div className="w-full flex items-center h-[8.5rem] bg-borderGray absolute bottom-[5.5rem] rounded-t-[0.625rem]">
-      <div className="w-full flex flex-col items-start gap-7 pl-3">
-        {/* <button className="flex font-semibold text-[1.125rem] w-full">수정</button> */}
-        <button className="flex font-semibold text-[1.125rem] w-full text-red-400" onClick={() => onRemove(id)}>
-          삭제
-        </button>
+    <ModalWrapper onClose={onClose}>
+      <div
+        className="w-full flex items-center h-[8.5rem] bg-borderGray absolute bg-black-400 bottom-[5.5rem] rounded-t-[0.625rem]"
+        onClick={e => e.stopPropagation()}>
+        <div className="w-full flex flex-col items-start gap-7 pl-3">
+          {/* <button className="flex font-semibold text-[1.125rem] w-full">수정</button> */}
+          <button className="flex font-semibold text-[1.125rem] w-full text-red-400" onClick={() => onRemove(id)}>
+            삭제
+          </button>
+        </div>
       </div>
-    </div>
+    </ModalWrapper>
   );
 }
 


### PR DESCRIPTION
## Modal

조금 더 간편하고 멋있게 만들 수도 있을 것 같은데 단계별로 업그레이드 시키기로하고.. 우선은 간단하게만

모달의 주요 기능
- 다른 element들 보다 상위에 그려진다.
- 백그라운드 클릭시 닫힌다.

모달 내부를 구현해서 자식으로만 넣어주면 위의 두 기능이 동작하게끔 추상화해놓은 ModalWarpper 컴포넌트를 만들어서 코드의 중복을 줄이고 로직을 숨겼습니다.



